### PR TITLE
Update deprecated deps

### DIFF
--- a/realskywars-plugin/pom.xml
+++ b/realskywars-plugin/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.14-R0.1-SNAPSHOT</version>
+            <version>1.14.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.10</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I update somes dependencies you used in RealSkywars to be able to build the plugin.

I would advise to not direclty merge this PR, and instead taking a look at the pom file. Placeholder API have changed their API, so papi may not work for now (but will failed to build if nothing is done anyways)